### PR TITLE
BluetoothSSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ V5Example contains the `ai_demo` V5 Project which has examples on how to connect
     ```
     dir C:\Users\%USERNAME%\.ssh
     ```
-6. If you don't see a file ending in `.pub`, run this command and don't forget to replace with your email, otherwise, skip to the next step
+6. If you see a file ending in `.pub`, skip this step. Otherwise, run this command and don't forget to replace with your email. Type enter to accept the default options for file location and to leave the passphrase blank.
     ```
-    ssh-keygen -t id_ed25519 -C "your_email@example.com"
+    ssh-keygen -t ed25519 -C "your_email@example.com"
     ```
 7. Run this command (change the path to the SSH key if needed), enter the password for the Jetson Nano user, then type `exit` to close the connection
    ```

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ V5Example contains the `ai_demo` V5 Project which has examples on how to connect
 11. Save the file
 12. In a new command prompt, run this command
     ```
-    ssh msoe-desktop
+    ssh msoe-nano1
     ```
 13. Check that you see this:
     ```
-    msoe@msoe-desktop:~$ 
+    msoe@msoe-nano1:~$ 
     ```
 14. If you do, congrats! You're all set to run commands on the Jetson Nano from your device!

--- a/README.md
+++ b/README.md
@@ -15,3 +15,40 @@ JetsonWebDashboard is where you will find the source code for the VEX AI Web Das
 ## [V5Example](./V5Example/ai_demo/README.md)
 
 V5Example contains the `ai_demo` V5 Project which has examples on how to connect with the Jetson Nano/Raspberry Pi and how to interpret and process the data from the board on the V5 Brain
+
+## SSH Access on Jetson Orin Nano
+
+1. Turn on the Jeton Nano
+2. Connect to `msoe-desktop` Wi-Fi
+3. Run this command to check if you have an SSH key made:
+    ```
+    dir C:\Users\%USERNAME%\.ssh
+    ```
+6. If you don't see a file ending in `.pub`, run this command and don't forget to replace with your email, otherwise, skip to the next step
+    ```
+    ssh-keygen -t id_ed25519 -C "your_email@example.com"
+    ```
+7. Run this command (change the path to the SSH key if needed), enter the password for the Jetson Nano user, then type `exit` to close the connection
+   ```
+   scp C:\Users\%USERNAME%\.ssh\id_ed25519.pub msoe@msoe-desktop:~/.ssh/authorized_keys
+   ```
+8. Edit `C:\Users\%USERNAME%\.ssh\config` You can open it in VSCode with this command:
+   ```
+   code C:\Users\%USERNAME%\.ssh\config
+   ```
+10. Add this to the file:
+    ```
+    Host msoe-desktop
+      HostName msoe-desktop
+      User msoe
+    ```
+11. Save the file
+12. In a new command prompt, run this command
+    ```
+    ssh msoe-desktop
+    ```
+13. Check that you see this:
+    ```
+    msoe@msoe-desktop:~$ 
+    ```
+14. If you do, congrats! You're all set to run commands on the Jetson Nano from your device!

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ V5Example contains the `ai_demo` V5 Project which has examples on how to connect
     ```
 7. Run this command (change the path to the SSH key if needed), enter the password for the Jetson Nano user, then type `exit` to close the connection
    ```
-   scp C:\Users\%USERNAME%\.ssh\id_ed25519.pub msoe@msoe-nano1:~/.ssh/authorized_keys
+   type C:\Users\%USERNAME%\.ssh\id_rsa.pub | ssh msoe-nano1 "cat >> ~/.ssh/authorized_keys"
    ```
 8. Edit `C:\Users\%USERNAME%\.ssh\config` You can open it in VSCode with this command:
    ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ V5Example contains the `ai_demo` V5 Project which has examples on how to connect
 ## SSH Access on Jetson Orin Nano
 
 1. Turn on the Jeton Nano
-2. Connect to `msoe-desktop` Wi-Fi
+2. Connect to `msoe-nano1` Wi-Fi
 3. Run this command to check if you have an SSH key made:
     ```
     dir C:\Users\%USERNAME%\.ssh
@@ -30,7 +30,7 @@ V5Example contains the `ai_demo` V5 Project which has examples on how to connect
     ```
 7. Run this command (change the path to the SSH key if needed), enter the password for the Jetson Nano user, then type `exit` to close the connection
    ```
-   scp C:\Users\%USERNAME%\.ssh\id_ed25519.pub msoe@msoe-desktop:~/.ssh/authorized_keys
+   scp C:\Users\%USERNAME%\.ssh\id_ed25519.pub msoe@msoe-nano1:~/.ssh/authorized_keys
    ```
 8. Edit `C:\Users\%USERNAME%\.ssh\config` You can open it in VSCode with this command:
    ```
@@ -38,8 +38,8 @@ V5Example contains the `ai_demo` V5 Project which has examples on how to connect
    ```
 10. Add this to the file:
     ```
-    Host msoe-desktop
-      HostName msoe-desktop
+    Host msoe-nano1
+      HostName msoe-nano1
       User msoe
     ```
 11. Save the file

--- a/pushback/bluetoothssh.sh
+++ b/pushback/bluetoothssh.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# This script is designed to allow the jetson nano to open an SSH connection over bluetooth
+
+set -euo pipefail
+
+# Function to clean on exit
+cleanup() {
+    echo "Cleaning up my oil spill..."
+    sudo pkill -f "rfcomm listen /dev/rfcomm0" || true
+    sudo pkill -f "socat TCP-LISTEN" || true
+    sudo hciconfig hci0 down || true
+    bluetoothctl <<EOF >/dev/null 2>&1 || true
+discoverable off
+pairable off
+EOF
+}
+trap cleanup EXIT
+
+# Package check
+for pack in bluez openssh-server socat; do
+    if ! dpkg -l | grep -q "^li $pack "; then
+        echo "Installing $pack..."
+        sudo apt-get install -y "$pack"
+    fi
+done
+
+sudo systemctl restart bluetooth
+sleep 2
+sudo systemctl enable --now ssh
+
+# Discoverability logic
+bluetoothctl << EOF
+power on
+agent on
+default-agent
+discoverable on
+pairable on
+EOF
+
+echo "Bluetooth is discoverable and pairable, awaiting SSH connection..."
+
+# Get the bluetooth MAC address
+BT_ADDR=$(bluetoothctl show | grep "Controller" | awk '{print $2}')
+echo "Bluetooth MAC address: $BT_ADDR"
+
+# pick a TCP port if 22 is in use
+if ss -ltn "( sport = :22 )" | grep -q LISTEN; then
+    PORT=2222
+else
+    PORT=22
+fi
+echo "Using TCP port $PORT for SSH"
+
+sudo hciconfig hci0 up
+sudo rfcomm release 0 || true
+
+cat > /tmp/bt_ssh_handler.sh << 'HANDLER_EOF'
+#!/bin/bash
+# This script handles each Bluetooth connection
+exec socat STDIO TCP:localhost:22
+HANDLER_EOF
+chmod +x /tmp/bt_ssh_handler.sh
+
+echo "Starting Bluetooth SSH bridge..."
+sudo rfcomm listen /dev/rfcomm0 1 /tmp/bt_ssh_handler.sh &
+RFCOMM_PID=$!
+
+echo "Bluetooth SSH bridge active (pid $RFCOMM_PID)"
+echo ""
+echo "========================" CONNECTION INSTRUCTIONS ========================"
+"Jetson Nano Bluetooth MAC: $BT_ADDR"
+""
+"FROM CLIENT DEVICE:"
+"1. Pair: bluetoothctl pair $BT_ADDR"
+"2. Trust: bluetoothctl trust $BT_ADDR"
+"3. Connect: sudo rfcomm connect /dev/rfcomm0 $BT_ADDR 1"
+"4. SSH: ssh username@localhost -o ProxyCommand='cat /dev/rfcomm0'"
+""
+"SIMPLE TEST:"
+"   sudo rfcomm connect /dev/rfcomm0 $BT_ADDR 1"
+"   # You should see SSH banner appear automatically"
+echo "========================================================================="
+
+while true; do
+    if ! kill -0 $RFCOMM_PID 2>/dev/null; then
+        echo "Restarting bridge..."
+        sudo rfcomm listen /dev/rfcomm0 1 /tmp/bt_ssh_handler.sh &
+        RFCOMM_PID=$!
+    fi
+    sleep 0.5
+done


### PR DESCRIPTION
This pull request introduces SSH access setup documentation for Jetson Orin Nano and adds a new script to enable SSH connections over Bluetooth for the Jetson Nano. The main changes improve developer onboarding and provide advanced connectivity options.

### Documentation improvements

* Added a detailed "SSH Access on Jetson Orin Nano" section to `README.md`, guiding users through generating SSH keys, configuring access, and connecting to the device.

### New Bluetooth SSH functionality

* Added `pushback/bluetoothssh.sh`, a script that sets up the Jetson Nano to accept SSH connections over Bluetooth, including package checks, Bluetooth configuration, connection instructions, and automatic bridge management.